### PR TITLE
Add --ignore-ctime-change option

### DIFF
--- a/doc/tar.texi
+++ b/doc/tar.texi
@@ -2852,6 +2852,11 @@ Ignore exit codes of subprocesses. @xref{Writing to an External Program}.
 Do not exit unsuccessfully merely because an unreadable file was encountered.
 @xref{Ignore Failed Read}.
 
+@opsummary{ignore-ctime-change}
+@item --ignore-ctime-change
+
+Do not exit unsuccessfully merely because the ctime of a file changed.
+
 @opsummary{ignore-zeros}
 @item --ignore-zeros
 @itemx -i

--- a/src/common.h
+++ b/src/common.h
@@ -166,6 +166,8 @@ GLOBAL gid_t group_option;
 
 GLOBAL bool ignore_failed_read_option;
 
+GLOBAL bool ignore_ctime_change_option;
+
 GLOBAL bool ignore_zeros_option;
 
 GLOBAL bool incremental_option;

--- a/src/create.c
+++ b/src/create.c
@@ -1829,7 +1829,8 @@ dump_file0 (struct tar_stat_info *st, char const *name, char const *p)
 
       if (ok)
 	{
-	  if ((timespec_cmp (get_stat_ctime (&final_stat), original_ctime) != 0
+	  if ((! ignore_ctime_change_option &&
+	       timespec_cmp (get_stat_ctime (&final_stat), original_ctime) != 0
 	       /* Original ctime will change if the file is a directory and
 		  --remove-files is given */
 	       && !(remove_files_option && is_dir))

--- a/src/tar.c
+++ b/src/tar.c
@@ -286,6 +286,7 @@ enum
   GROUP_MAP_OPTION,
   IGNORE_COMMAND_ERROR_OPTION,
   IGNORE_FAILED_READ_OPTION,
+  IGNORE_CTIME_CHANGE_OPTION,
   INDEX_FILE_OPTION,
   KEEP_DIRECTORY_SYMLINK_OPTION,
   KEEP_NEWER_FILES_OPTION,
@@ -433,6 +434,8 @@ static struct argp_option options[] = {
    N_("dump level for created listed-incremental archive"), GRID+1 },
   {"ignore-failed-read", IGNORE_FAILED_READ_OPTION, 0, 0,
    N_("do not exit with nonzero on unreadable files"), GRID+1 },
+  {"ignore-ctime-change", IGNORE_CTIME_CHANGE_OPTION, 0, 0,
+   N_("do not exit with nonzero when the ctime changes"), GRID+1 },
   {"occurrence", OCCURRENCE_OPTION, N_("NUMBER"), OPTION_ARG_OPTIONAL,
    N_("process only the NUMBERth occurrence of each file in the archive;"
       " this option is valid only in conjunction with one of the subcommands"
@@ -1732,6 +1735,10 @@ parse_opt (int key, char *arg, struct argp_state *state)
 
     case IGNORE_FAILED_READ_OPTION:
       ignore_failed_read_option = true;
+      break;
+
+    case IGNORE_CTIME_CHANGE_OPTION:
+      ignore_ctime_change_option = true;
       break;
 
     case KEEP_DIRECTORY_SYMLINK_OPTION:


### PR DESCRIPTION
The use case is to ignore ctime changes due to changes of the link count,
for instance when hardlinks are used as a snapshotting technique with
immutable files.

Ref: http://mail-archives.apache.org/mod_mbox/cassandra-user/201605.mbox/%3C571BC296-B4F4-49E8-A480-850AFDF84360@uplex.de%3E
